### PR TITLE
Added go_to_state as atribute

### DIFF
--- a/src/loqedAPI/loqed.py
+++ b/src/loqedAPI/loqed.py
@@ -65,6 +65,7 @@ class Lock:
         self.last_key_id = ""
         self.waitforstate = False
         self.last_event = ""
+        self.go_to_state = ""
         self.id = self.raw_data["bridge_mac_wifi"]
     
     @property
@@ -224,6 +225,7 @@ class Lock:
                 if "night_lock" in self.last_event: self.bolt_state="locking"
                 if "open" in self.last_event: self.bolt_state="opening"
                 if "latch" in self.last_event: self.bolt_state="unlocking"
+                self.go_to_state = sstr.replace(self.last_event,"go_to_state_","")
             self.last_key_id=data["key_local_id"]
         return data
 

--- a/src/loqedAPI/loqed.py
+++ b/src/loqedAPI/loqed.py
@@ -95,7 +95,7 @@ class Lock:
         command_type_bin = struct.pack("B", 7)
         local_key_id_bin = struct.pack("B", self.key_id)
         device_id_bin = struct.pack("B", 1)
-        action_bin =  struct.pack("B", action)
+        action_bin =  struct.pack("B", action.value)
         now=int(time.time())
         timenow_bin=now.to_bytes(8, 'big', signed=False)
         local_generated_binary_hash = protocol_bin + command_type_bin + timenow_bin + local_key_id_bin + device_id_bin + action_bin

--- a/src/loqedAPI/loqed.py
+++ b/src/loqedAPI/loqed.py
@@ -225,7 +225,7 @@ class Lock:
                 if "night_lock" in self.last_event: self.bolt_state="locking"
                 if "open" in self.last_event: self.bolt_state="opening"
                 if "latch" in self.last_event: self.bolt_state="unlocking"
-                self.go_to_state = sstr.replace(self.last_event,"go_to_state_","")
+                self.go_to_state = str.replace(self.last_event,"go_to_state_","")
             self.last_key_id=data["key_local_id"]
         return data
 


### PR DESCRIPTION
Added go to state as attribute which will capture the lat go to state. ~This will help to identify the action that triggered the state change. For example if you want to use the unlock of you front door lock to switch off your alarm it can be important to know if it was triggered by turning the door knob (what a burglar can do) or from the outside by the app.