### PR TITLE
Fix ContentTypeError with new Shelly-based gateway

### DIFF
--- a/src/loqedAPI/loqed.py
+++ b/src/loqedAPI/loqed.py
@@ -166,7 +166,7 @@ class Lock:
         "Update status"
         resp = await self.apiclient.request("get", "status")
         resp.raise_for_status()
-        json_data = await resp.json(content_type="text/html")
+        json_data = await resp.json(content_type=None)
         self.raw_data = json_data
         self.bolt_state = self.raw_data["bolt_state"]
         return json_data
@@ -180,7 +180,7 @@ class Lock:
         headers = {"TIMESTAMP": str(now), "HASH": hash}
         resp = await self.apiclient.request("get", f"webhooks", headers=headers)
         resp.raise_for_status()
-        json_data = await resp.json(content_type="text/html")
+        json_data = await resp.json(content_type=None)
         _LOGGER.debug("get Webhooks Response: %s", str(json_data))
         self.webhooks = {}
         return json_data
@@ -322,7 +322,7 @@ class LoqedAPI:
         resp = await self.apiclient.request("get", "status")
         resp.raise_for_status()
         _LOGGER.debug("Response get lock details: %s", await resp.text())
-        json_data = await resp.json(content_type="text/html")
+        json_data = await resp.json(content_type=None)
         return json_data
 
     async def async_get_lock(
@@ -331,7 +331,7 @@ class LoqedAPI:
         """Return the locks with lock-data"""
         if not json_data:
             resp = await self.apiclient.request("get", "status")
-            json_data = await resp.json(content_type="text/html")
+            json_data = await resp.json(content_type=None)
         return Lock(json_data, secret, bridgekey, key_id, name, self.apiclient)
 
 


### PR DESCRIPTION
## Problem

Home Assistant zero-config (mDNS) discovery silently fails with the new Shelly-based LOQED bridge gateway.

All four `resp.json()` calls in `loqed.py` were using `content_type="text/html"`, which makes aiohttp raise a `ContentTypeError` if the server returns anything other than `text/html`.

| Gateway | Content-Type returned | Result |
|---|---|---|
| Old ESP32 bridge | `text/html` | ✅ Works |
| New Shelly gateway | `application/json` | ❌ `ContentTypeError` |

The error propagates uncaught out of `async_step_zeroconf` in the HA config flow, causing the entire discovery flow to silently abort.

## Fix

Change all four calls from:
```python
await resp.json(content_type="text/html")
```
to:
```python
await resp.json(content_type=None)
```

Passing `content_type=None` skips aiohttp's Content-Type validation entirely (the `if content_type:` check in aiohttp's source is falsy for `None`). The JSON body is decoded regardless of what header the server sends.

This works correctly for both gateways:
- **Old ESP32 bridge** (`text/html`) — validation skipped, JSON decoded ✅
- **New Shelly gateway** (`application/json`) — validation skipped, JSON decoded ✅

## Files changed

- `src/loqedAPI/loqed.py` — 4 occurrences updated (`Lock.update`, `Lock.getWebhooks`, `LoqedAPI.async_get_lock_details`, `LoqedAPI.async_get_lock`)